### PR TITLE
[Feat] 하루 감정 통계 api, 감정 저장 api 추가

### DIFF
--- a/src/main/java/Spring/MindStone/domain/diary/DailyEmotionStatistic.java
+++ b/src/main/java/Spring/MindStone/domain/diary/DailyEmotionStatistic.java
@@ -1,14 +1,19 @@
 package Spring.MindStone.domain.diary;
 
+import Spring.MindStone.domain.enums.EmotionList;
 import Spring.MindStone.domain.member.MemberInfo;
 import Spring.MindStone.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
+
 @Entity
 @Getter
 @Builder
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor
 @AllArgsConstructor
 /*@IdClass(DailyEmotionStatisticId.class) // 복합 키 클래스 매핑*/
 public class DailyEmotionStatistic extends BaseEntity {
@@ -22,9 +27,9 @@ public class DailyEmotionStatistic extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false) // MemberInfo와 연관 관계
     private MemberInfo memberInfo;
 
-    /*@Id
+
     @Column(nullable = false)
-    private LocalDate date; // 생성 날짜 (복합 키)*/
+    private LocalDate date; // 생성 날짜
 
     @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 0")
     private Integer angerFigure; // 분노 수치
@@ -36,6 +41,9 @@ public class DailyEmotionStatistic extends BaseEntity {
     private Integer sadFigure; // 슬픔 수치
 
     @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 0")
+    private Integer calmFigure; // 슬픔 수치
+
+    @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 0")
     private Integer joyFigure; // 기쁨 수치
 
     @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 0")
@@ -43,4 +51,21 @@ public class DailyEmotionStatistic extends BaseEntity {
 
     @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 0")
     private Integer happinessFigure; // 행복 수치
+
+    public void updateEmotion(EmotionList emotion, int value) {
+        switch (emotion) {
+            case ANGER -> this.angerFigure += value;
+            case DEPRESSION -> this.depressionFigure += value;
+            case SAD -> this.sadFigure += value;
+            case CALM -> this.calmFigure += value;
+            case JOY -> this.joyFigure += value;
+            case THRILL -> this.thrillFigure += value;
+            case HAPPINESS -> this.happinessFigure += value;
+        }
+    }
+
+    public DailyEmotionStatistic(MemberInfo memberInfo, LocalDate date){
+        this.memberInfo = memberInfo;
+        this.date = date;
+    }
 }

--- a/src/main/java/Spring/MindStone/domain/enums/EmotionList.java
+++ b/src/main/java/Spring/MindStone/domain/enums/EmotionList.java
@@ -3,7 +3,7 @@ package Spring.MindStone.domain.enums;
 import java.util.Arrays;
 
 public enum EmotionList {
-    ANGER, DEPRESSION, SAD, JOY, THRILL, HAPPINESS;
+    ANGER, DEPRESSION, SAD, CALM, JOY, THRILL, HAPPINESS;
 
     public static EmotionList fromString(String emotion) {
         return Arrays.stream(values()) // ✅ 배열을 Stream으로 변환

--- a/src/main/java/Spring/MindStone/repository/diaryRepository/DailyEmotionStatisticRepository.java
+++ b/src/main/java/Spring/MindStone/repository/diaryRepository/DailyEmotionStatisticRepository.java
@@ -1,0 +1,13 @@
+package Spring.MindStone.repository.diaryRepository;
+
+import Spring.MindStone.domain.diary.DailyEmotionStatistic;
+import Spring.MindStone.domain.diary.DiaryImage;
+import Spring.MindStone.domain.member.MemberInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface DailyEmotionStatisticRepository extends JpaRepository<DailyEmotionStatistic, Long> {
+    Optional<Object> findByDateAndMemberInfo(LocalDate date, MemberInfo memberInfo);
+}

--- a/src/main/java/Spring/MindStone/repository/memberRepository/MemberInterestRepository.java
+++ b/src/main/java/Spring/MindStone/repository/memberRepository/MemberInterestRepository.java
@@ -1,0 +1,12 @@
+package Spring.MindStone.repository.memberRepository;
+
+import Spring.MindStone.domain.member.MemberInfo;
+import Spring.MindStone.domain.member.MemberInterest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberInterestRepository extends JpaRepository<MemberInterest, Long> {
+
+    MemberInterest getMemberInterestById(Long memberId);
+}

--- a/src/main/java/Spring/MindStone/service/diaryService/DailyEmotionStatisticService.java
+++ b/src/main/java/Spring/MindStone/service/diaryService/DailyEmotionStatisticService.java
@@ -1,0 +1,39 @@
+package Spring.MindStone.service.diaryService;
+
+import Spring.MindStone.domain.diary.DailyEmotionStatistic;
+import Spring.MindStone.domain.enums.EmotionList;
+import Spring.MindStone.domain.member.MemberInfo;
+import Spring.MindStone.repository.diaryRepository.DailyEmotionStatisticRepository;
+import Spring.MindStone.service.memberInfoService.MemberInfoService;
+import Spring.MindStone.web.dto.emotionDto.SimpleEmotionStatisticDto;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class DailyEmotionStatisticService {
+    private final DailyEmotionStatisticRepository dailyEmotionStatisticRepository;
+    private final MemberInfoService memberInfoService;
+
+
+    public DailyEmotionStatistic saveStatistics(MemberInfo memberInfo, LocalDate date, EmotionList emotion, int figure) {
+        DailyEmotionStatistic statistics = (DailyEmotionStatistic) dailyEmotionStatisticRepository.findByDateAndMemberInfo(date,memberInfo)
+                .orElseGet(() -> new DailyEmotionStatistic(memberInfo, date)); // 없으면 생성
+
+        statistics.updateEmotion(emotion, figure);
+
+        return dailyEmotionStatisticRepository.save(statistics); // 저장 후 반환
+    }
+
+    public SimpleEmotionStatisticDto getStatistic(Long memberId) {
+        MemberInfo memberInfo = memberInfoService.findMemberById(memberId);
+        DailyEmotionStatistic statistics = (DailyEmotionStatistic) dailyEmotionStatisticRepository.findByDateAndMemberInfo(LocalDate.now(),memberInfo)
+                .orElseGet(() -> new DailyEmotionStatistic(memberInfo, LocalDate.now()));
+
+        return new SimpleEmotionStatisticDto(statistics);
+    }
+}

--- a/src/main/java/Spring/MindStone/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/Spring/MindStone/service/diaryService/DiaryCommandServiceImpl.java
@@ -12,6 +12,7 @@ import Spring.MindStone.repository.diaryRepository.DiaryRepository;
 import Spring.MindStone.repository.memberRepository.MemberInfoRepository;
 import Spring.MindStone.service.emotionNoteService.EmotionNoteQueryService;
 import Spring.MindStone.service.FileService;
+import Spring.MindStone.service.memberInfoService.MemberInfoService;
 import Spring.MindStone.web.dto.diaryDto.DiaryResponseDTO;
 import Spring.MindStone.web.dto.diaryDto.DiarySaveDTO;
 import Spring.MindStone.web.dto.diaryDto.DiaryUpdateDTO;
@@ -41,6 +42,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService {
     private final DiaryQueryService diaryQueryService;
     private final DiaryRepository diaryRepository;
     private final MemberInfoRepository memberInfoRepository;
+    private final MemberInfoService memberInfoService;
     private final FileService fileService;
     private final DiaryImageRepository diaryImageRepository;
     private final DiaryQueryServiceImpl diaryQueryServiceImpl;
@@ -187,8 +189,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService {
 
     @Override
     public SimpleDiaryDTO saveDiary(DiarySaveDTO saveDTO, Long memberId,List<MultipartFile> image){
-        MemberInfo memberInfo = memberInfoRepository.findById(memberId)
-                .orElseThrow(() -> new MemberInfoHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        MemberInfo memberInfo = memberInfoService.findMemberById(memberId);
 
         //이미지만 설정안했음!
         DailyDiary diary = DailyDiary.builder()
@@ -211,8 +212,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService {
     }
 
     public SimpleDiaryDTO deleteDiary(Long id, Long memberId){
-        MemberInfo memberInfo = memberInfoRepository.findById(memberId)
-                .orElseThrow(() -> new MemberInfoHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        MemberInfo memberInfo = memberInfoService.findMemberById(memberId);
         DailyDiary diary =diaryRepository.findDailyDiaryByDate(memberId, LocalDate.now())
                 .orElseThrow(() ->new MemberInfoHandler(ErrorStatus.DIARY_NOT_FOUND));
 

--- a/src/main/java/Spring/MindStone/service/emotionNoteService/EmotionNoteService.java
+++ b/src/main/java/Spring/MindStone/service/emotionNoteService/EmotionNoteService.java
@@ -1,0 +1,41 @@
+package Spring.MindStone.service.emotionNoteService;
+
+import Spring.MindStone.apiPayload.code.status.ErrorStatus;
+import Spring.MindStone.apiPayload.exception.handler.MemberInfoHandler;
+import Spring.MindStone.domain.emotion.EmotionNote;
+import Spring.MindStone.domain.enums.EmotionList;
+import Spring.MindStone.domain.member.MemberInfo;
+import Spring.MindStone.repository.diaryRepository.DailyEmotionStatisticRepository;
+import Spring.MindStone.repository.emotionNoteRepository.EmotionNoteRepository;
+import Spring.MindStone.service.diaryService.DailyEmotionStatisticService;
+import Spring.MindStone.service.memberInfoService.MemberInfoService;
+import Spring.MindStone.web.dto.emotionNoteDto.EmotionNoteSaveDTO;
+import Spring.MindStone.web.dto.emotionNoteDto.SimpleEmotionNoteDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class EmotionNoteService {
+    private final EmotionNoteRepository emotionNoteRepository;
+    private final MemberInfoService memberInfoService;
+    private final DailyEmotionStatisticRepository dailyEmotionStatisticRepository;
+    private final DailyEmotionStatisticService dailyEmotionStatisticService;
+
+    public SimpleEmotionNoteDTO saveEmotionNote(EmotionNoteSaveDTO note, Long memberId) {
+        MemberInfo memberInfo = memberInfoService.findMemberById(memberId);
+        EmotionNote emotionNote = EmotionNote.builder()
+                .memberInfo(memberInfo)
+                .emotionFigure(note.getEmotionFigure())
+                .emotion(EmotionList.fromString(note.getEmotion()))
+                .content(note.getContent()).build();
+
+        dailyEmotionStatisticService.saveStatistics(memberInfo, LocalDate.now()
+                ,EmotionList.fromString(note.getEmotion()),note.getEmotionFigure());
+
+        emotionNoteRepository.save(emotionNote);
+        return new SimpleEmotionNoteDTO(emotionNote);
+    }
+}

--- a/src/main/java/Spring/MindStone/service/memberInfoService/MemberInterestService.java
+++ b/src/main/java/Spring/MindStone/service/memberInfoService/MemberInterestService.java
@@ -1,0 +1,21 @@
+package Spring.MindStone.service.memberInfoService;
+
+import Spring.MindStone.domain.member.MemberInterest;
+import Spring.MindStone.repository.memberRepository.MemberInterestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemberInterestService {
+    private final MemberInterestRepository memberInterestRepository;
+
+    public String getStressActionMine(Long memberId){
+        MemberInterest memberInterest = memberInterestRepository.getMemberInterestById(memberId);
+        List<String> actionList = Arrays.asList(memberInterest.getStressActions().split(","));
+        return null;
+    }
+}

--- a/src/main/java/Spring/MindStone/web/controller/EmotionNoteController.java
+++ b/src/main/java/Spring/MindStone/web/controller/EmotionNoteController.java
@@ -1,0 +1,46 @@
+package Spring.MindStone.web.controller;
+
+import Spring.MindStone.apiPayload.ApiResponse;
+import Spring.MindStone.config.jwt.JwtTokenUtil;
+import Spring.MindStone.repository.emotionNoteRepository.EmotionNoteRepository;
+import Spring.MindStone.service.diaryService.DailyEmotionStatisticService;
+import Spring.MindStone.service.emotionNoteService.EmotionNoteQueryService;
+import Spring.MindStone.service.emotionNoteService.EmotionNoteService;
+import Spring.MindStone.web.dto.emotionDto.SimpleEmotionStatisticDto;
+import Spring.MindStone.web.dto.emotionNoteDto.EmotionNoteSaveDTO;
+import Spring.MindStone.web.dto.emotionNoteDto.SimpleEmotionNoteDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/emotionnote")
+@RequiredArgsConstructor
+@Tag(name = "EmotionManagerment", description = "감정에 대한 일과 기록 및 해결")
+public class EmotionNoteController {
+
+    private final EmotionNoteQueryService emotionNoteQueryService;
+    private final EmotionNoteService emotionNoteService;
+    private final DailyEmotionStatisticService dailyEmotionStatisticService;
+
+    @PostMapping
+    @Operation(summary = "감정 일과 기록", description = "감정에 대한 일과 저장")
+    ApiResponse<SimpleEmotionNoteDTO> saveEmotionNote(
+            @Valid @RequestBody EmotionNoteSaveDTO emotionNoteDTO,
+            @RequestHeader("Authorization") String authorization) {
+        Long memberId = JwtTokenUtil.extractMemberId(authorization);
+
+        return ApiResponse.onSuccess(emotionNoteService.saveEmotionNote(emotionNoteDTO,memberId));
+    }
+
+    @GetMapping("/statistic")
+    @Operation(summary = "하루 사용자의 감정 통계 내줌(홈화면 그래프)")
+    ApiResponse<SimpleEmotionStatisticDto> statisticEmotionNote(@RequestHeader("Authorization") String authorization){
+        Long memberId = JwtTokenUtil.extractMemberId(authorization);
+        return ApiResponse.onSuccess(dailyEmotionStatisticService.getStatistic(memberId));
+    }
+
+
+}

--- a/src/main/java/Spring/MindStone/web/controller/MemberInterestController.java
+++ b/src/main/java/Spring/MindStone/web/controller/MemberInterestController.java
@@ -1,0 +1,32 @@
+package Spring.MindStone.web.controller;
+
+import Spring.MindStone.service.memberInfoService.MemberInterestService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/emotionManagement")
+@RequiredArgsConstructor
+@Tag(name = "EmotionManagerment", description = "감정에 대한 일과 기록 및 해결")
+public class MemberInterestController {
+    private final MemberInterestService memberInterestService;
+
+    /*@GetMapping("/")
+    ApiResponse<String> getStressAcitonMine(@RequestHeader("Authorization") String authorization){
+        Long memberId = JwtTokenUtil.extractMemberId(authorization);
+        return ApiResponse.onSuccess(memberInterestService.getStressActionMine(memberId));
+    }
+
+    @GetMapping("/mbti")
+    ApiResponse<String> getStressActionOtherByMBTI(@RequestPart(value = "mbti", required = false) String mbti
+            ,@RequestHeader("Authorization") String authorization){
+        Long memberId = JwtTokenUtil.extractMemberId(authorization);
+        return null;
+    }
+
+    @GetMapping("/job")
+    ApiResponse<String> getStressActionOtherByJob(){
+        return null;
+    }*/
+}

--- a/src/main/java/Spring/MindStone/web/dto/emotionDto/SimpleEmotionStatisticDto.java
+++ b/src/main/java/Spring/MindStone/web/dto/emotionDto/SimpleEmotionStatisticDto.java
@@ -1,0 +1,43 @@
+package Spring.MindStone.web.dto.emotionDto;
+
+import Spring.MindStone.domain.diary.DailyEmotionStatistic;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public class SimpleEmotionStatisticDto {
+    @Schema(description = "통계가 저장된 날짜", example = "2024-02-01")
+    private LocalDate date;
+
+    @Schema(description = "분노 수치", example = "5")
+    private Integer angerFigure;
+
+    @Schema(description = "우울 수치", example = "3")
+    private Integer depressionFigure;
+
+    @Schema(description = "슬픔 수치", example = "4")
+    private Integer sadFigure;
+
+    @Schema(description = "평온 수치", example = "7")
+    private Integer calmFigure;
+
+    @Schema(description = "기쁨 수치", example = "6")
+    private Integer joyFigure;
+
+    @Schema(description = "전율 수치", example = "2")
+    private Integer thrillFigure;
+
+    @Schema(description = "행복 수치", example = "8")
+    private Integer happinessFigure;
+
+    public SimpleEmotionStatisticDto(DailyEmotionStatistic entity) {
+        this.date = entity.getDate();
+        this.angerFigure = entity.getAngerFigure();
+        this.depressionFigure = entity.getDepressionFigure();
+        this.sadFigure = entity.getSadFigure();
+        this.calmFigure = entity.getCalmFigure();
+        this.joyFigure = entity.getJoyFigure();
+        this.thrillFigure = entity.getThrillFigure();
+        this.happinessFigure = entity.getHappinessFigure();
+    }
+}

--- a/src/main/java/Spring/MindStone/web/dto/emotionNoteDto/EmotionNoteSaveDTO.java
+++ b/src/main/java/Spring/MindStone/web/dto/emotionNoteDto/EmotionNoteSaveDTO.java
@@ -1,0 +1,23 @@
+package Spring.MindStone.web.dto.emotionNoteDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class EmotionNoteSaveDTO {
+    @NotNull(message = "무슨 감정을 느꼈는지 적어야합니다.")
+    @Schema(description = "감정", example = "ANGER, DEPRESSION, SAD, CALM, JOY, THRILL, HAPPINESS")
+    private String emotion;
+
+    @NotNull(message = "감정을 얼마나 느꼈는지 적어야합니다.")
+    @Schema(description = "감정수치", example = "10~100")
+    private Integer emotionFigure;
+
+    @Schema(description = "감정이유 작성", example = "외출을 다짐했는데 비가 와서 슬펐다.")
+    private String content;
+}

--- a/src/main/java/Spring/MindStone/web/dto/emotionNoteDto/SimpleEmotionNoteDTO.java
+++ b/src/main/java/Spring/MindStone/web/dto/emotionNoteDto/SimpleEmotionNoteDTO.java
@@ -1,0 +1,31 @@
+package Spring.MindStone.web.dto.emotionNoteDto;
+
+import Spring.MindStone.domain.emotion.EmotionNote;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class SimpleEmotionNoteDTO {
+
+    private Long id;
+
+    @NotNull(message = "무슨 감정을 느꼈는지 적어야합니다.")
+    @Schema(description = "감정", example = "ANGER, DEPRESSION, SAD, CALM, JOY, THRILL, HAPPINESS")
+    private String emotion;
+
+    @NotNull(message = "감정을 얼마나 느꼈는지 적어야합니다.")
+    @Schema(description = "감정수치", example = "10~100")
+    private Integer emotionFigure;
+
+    @Schema(description = "감정이유 작성", example = "외출을 다짐했는데 비가 와서 슬펐다.")
+    private String content;
+
+    public SimpleEmotionNoteDTO(EmotionNote emotionNote) {
+        id = emotionNote.getId();
+        emotion =emotionNote.getEmotion().toString();
+        emotionFigure = emotionNote.getEmotionFigure();
+        content = emotionNote.getContent();
+    }
+
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
- #22 

## 📍 작업 내용
EmotionNoteController 참고하면
사용자의 하루 감정 상태(분노 몇, 행복 몇 이렇게 띄워줌)
사용자가 감정 기록하는것에 대한 api 추가함
변경 내용 : EmotionList enum과 감정통계 엔티티에 calm이라는 감정 없어서 추가 DiaryCommandServiceImpl에서 레포지토리 접근하지 않고 서비스에서 MemberInfo받아옴


## ✚ 리뷰 요구사항
- 연주의 부분과 좀 겹치는 요소가 있고, 엔티티의 부분이 좀 바뀜.(DailyEmotionStatistic) 