### PR TITLE
[Feat] 로그아웃, 회원탈퇴 기능 구현

### DIFF
--- a/src/main/java/Spring/MindStone/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/Spring/MindStone/apiPayload/code/status/ErrorStatus.java
@@ -19,6 +19,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "존재하지 않는 사용자입니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER4002", "이미 존재하는 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER4003", "비밀번호가 일치하지 않습니다."),
+    INACTIVE_MEMBER(HttpStatus.UNAUTHORIZED, "MEMBER4004", "비활성화 된 사용자입니다."),
 
     //인증 관련 에러
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH4001", "이메일 또는 비밀번호가 일치하지 않습니다."),

--- a/src/main/java/Spring/MindStone/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/Spring/MindStone/apiPayload/code/status/ErrorStatus.java
@@ -27,6 +27,7 @@ public enum ErrorStatus implements BaseErrorCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH4012", "토큰이 만료되었습니다."),
     VERIFICATION_CODE_WRONG(HttpStatus.BAD_REQUEST, "AUTH4021", "인증번호가 일치하지 않습니다."),
     VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "AUTH4022", "인증번호가 만료되었습니다."),
+    LOGOUT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4023", "로그아웃된 토큰입니다."),
 
     // 감정 관련 에러
     EMOTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "EMOTION4001", "존재하지 않는 감정 ID 입니다."),

--- a/src/main/java/Spring/MindStone/config/SchedulerConfig.java
+++ b/src/main/java/Spring/MindStone/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package Spring.MindStone.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/Spring/MindStone/config/jwt/JwtRequestFilter.java
+++ b/src/main/java/Spring/MindStone/config/jwt/JwtRequestFilter.java
@@ -1,5 +1,8 @@
 package Spring.MindStone.config.jwt;
 
+import Spring.MindStone.apiPayload.code.status.ErrorStatus;
+import Spring.MindStone.apiPayload.exception.handler.AuthHandler;
+import Spring.MindStone.service.tokenBlacklistService.TokenBlacklistService;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -22,6 +25,7 @@ import java.io.IOException;
 public class JwtRequestFilter extends OncePerRequestFilter {
 
     private final UserDetailsService userDetailsService;
+    private final TokenBlacklistService tokenBlacklistService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -34,6 +38,11 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
         if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
             token = authorizationHeader.substring(7);
+
+            if (tokenBlacklistService.isTokenBlacklisted(token)) {
+                throw new AuthHandler(ErrorStatus.LOGOUT_TOKEN);
+            }
+
             try {
                 Claims claims = JwtTokenUtil.validateToken(token);
                 username = claims.getSubject();

--- a/src/main/java/Spring/MindStone/config/jwt/JwtTokenUtil.java
+++ b/src/main/java/Spring/MindStone/config/jwt/JwtTokenUtil.java
@@ -12,12 +12,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 
 @Component
 public class JwtTokenUtil {
 
-    private static final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 60; // 1시간
+    private static final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 30; // 30분
     private static final long REFRESH_TOKEN_EXPIRATION = 7 * 24 * 60 * 60 * 1000; // 7일
 
     @Value("${spring.jwt.secret-key}")
@@ -94,16 +96,20 @@ public class JwtTokenUtil {
     public static String extractUserEmail(String token) {
         String accessToken = token.substring(7);
         Claims claims = validateToken(accessToken);
-        System.out.println(claims.getSubject());
         String email = claims.getSubject();
-        System.out.println("Email : " + email);
         if (email == null || email.isEmpty()) {
             throw new AuthHandler(ErrorStatus.INVALID_TOKEN);  // 커스텀 예외 처리
         }
         return email;
     }
 
-
+    public static LocalDateTime getExpirationDate(String token) {
+        Claims claims = validateToken(token);
+        return claims.getExpiration()
+                .toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
+    }
 
     public static class InvalidTokenException extends RuntimeException {
         public InvalidTokenException(String message) {

--- a/src/main/java/Spring/MindStone/config/security/CustomUserDetailsService.java
+++ b/src/main/java/Spring/MindStone/config/security/CustomUserDetailsService.java
@@ -2,6 +2,8 @@ package Spring.MindStone.config.security;
 
 import Spring.MindStone.apiPayload.code.status.ErrorStatus;
 import Spring.MindStone.apiPayload.exception.handler.AuthHandler;
+import Spring.MindStone.apiPayload.exception.handler.MemberInfoHandler;
+import Spring.MindStone.domain.enums.Status;
 import Spring.MindStone.domain.member.MemberInfo;
 import Spring.MindStone.repository.memberRepository.MemberInfoRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,11 +20,19 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        System.out.println(username);
-        MemberInfo memberInfo = memberInfoRepository.findByEmail(username)
-                .orElseThrow(() -> new AuthHandler(ErrorStatus.AUTHENTICATION_FAILED));
 
-         System.out.println(memberInfo.getPassword());
+        System.out.println("email : " + username);
+
+        MemberInfo memberInfo = memberInfoRepository.findByEmail(username)
+                .orElseThrow(() -> {
+                    System.out.println("User not found: " + username);
+                    return new AuthHandler(ErrorStatus.AUTHENTICATION_FAILED);
+                });
+
+        if (memberInfo.getStatus() == Status.INACTIVE) {
+            System.out.println("Inactive Member");
+            throw new MemberInfoHandler(ErrorStatus.INACTIVE_MEMBER);
+        }
 
         return org.springframework.security.core.userdetails.User
                 .withUsername(memberInfo.getEmail())

--- a/src/main/java/Spring/MindStone/config/security/SecurityConfig.java
+++ b/src/main/java/Spring/MindStone/config/security/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
                         .requestMatchers("/", "/api/auth/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/members").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // 스웨거 api
-                        .requestMatchers("/api/test/auth/**", "/api/diary/**", "/api/members/**", "/api/habits/**" /* "/api/members/survey"*/).hasRole("USER")
+                        .requestMatchers("/api/test/auth/**", "/api/diary/**", "/api/members/**", "/api/habits/**", "/api/members/survey", "/api/auth/logout").hasRole("USER")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class) // JWT 필터

--- a/src/main/java/Spring/MindStone/domain/listener/MemberEntityListner.java
+++ b/src/main/java/Spring/MindStone/domain/listener/MemberEntityListner.java
@@ -1,0 +1,18 @@
+package Spring.MindStone.domain.listener;
+
+import Spring.MindStone.apiPayload.code.status.ErrorStatus;
+import Spring.MindStone.apiPayload.exception.handler.MemberInfoHandler;
+import Spring.MindStone.domain.enums.Status;
+import Spring.MindStone.domain.member.MemberInfo;
+import jakarta.persistence.PostLoad;
+
+public class MemberEntityListner {
+
+    @PostLoad
+    public void filterInactiveMembers(MemberInfo member) {
+        if (member.getStatus() == Status.INACTIVE) {
+            System.out.println("Inactive Member");
+            throw new MemberInfoHandler(ErrorStatus.INACTIVE_MEMBER);
+        }
+    }
+}

--- a/src/main/java/Spring/MindStone/domain/member/MemberInfo.java
+++ b/src/main/java/Spring/MindStone/domain/member/MemberInfo.java
@@ -8,6 +8,7 @@ import Spring.MindStone.domain.enums.MBTI;
 import Spring.MindStone.domain.enums.Role;
 import Spring.MindStone.domain.enums.Status;
 import Spring.MindStone.domain.habit.Habit;
+import Spring.MindStone.domain.listener.MemberEntityListner;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
@@ -23,6 +24,7 @@ import java.util.List;
 @Builder
 @DynamicUpdate
 @DynamicInsert
+@EntityListeners(MemberEntityListner.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class MemberInfo extends BaseEntity {

--- a/src/main/java/Spring/MindStone/domain/tokenBlacklist/TokenBlackList.java
+++ b/src/main/java/Spring/MindStone/domain/tokenBlacklist/TokenBlackList.java
@@ -1,0 +1,31 @@
+package Spring.MindStone.domain.tokenBlacklist;
+
+import Spring.MindStone.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class TokenBlackList extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+}

--- a/src/main/java/Spring/MindStone/repository/memberRepository/MemberInfoRepository.java
+++ b/src/main/java/Spring/MindStone/repository/memberRepository/MemberInfoRepository.java
@@ -1,13 +1,18 @@
 package Spring.MindStone.repository.memberRepository;
 
+import Spring.MindStone.domain.enums.Status;
 import Spring.MindStone.domain.member.MemberInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface MemberInfoRepository extends JpaRepository<MemberInfo, Long> {
     boolean existsByEmail(String email);
     Optional<MemberInfo> findByEmail(String email);     // 이메일로 회원 정보 조회
+
+    List<MemberInfo> findByStatusAndInactiveDateBefore(Status status, LocalDate inactiveDate);
 }

--- a/src/main/java/Spring/MindStone/repository/tokenBlacklistRepository/TokenBlacklistRepository.java
+++ b/src/main/java/Spring/MindStone/repository/tokenBlacklistRepository/TokenBlacklistRepository.java
@@ -1,0 +1,19 @@
+package Spring.MindStone.repository.tokenBlacklistRepository;
+
+import Spring.MindStone.domain.tokenBlacklist.TokenBlackList;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface TokenBlacklistRepository extends JpaRepository<TokenBlackList, Long> {
+    Optional<TokenBlackList> findByToken(String token);
+    boolean existsByToken(String token);
+
+    @Modifying
+    @Query("DELETE FROM TokenBlackList t WHERE t.expiredAt < :now")
+    void deleteAllByExpiredAtBefore(LocalDateTime now);
+
+}

--- a/src/main/java/Spring/MindStone/service/authService/AuthService.java
+++ b/src/main/java/Spring/MindStone/service/authService/AuthService.java
@@ -36,7 +36,6 @@ public class AuthService {
 
             String accessToken = JwtTokenUtil.generateAccessToken(loginDto.getEmail(), memberInfoService);
             String refreshToken = JwtTokenUtil.generateRefreshToken(loginDto.getEmail(), memberInfoService);
-            System.out.println(JwtTokenUtil.getExpirationDate(refreshToken));
 
             return MemberInfoResponseDTO.LoginResponseDto.builder()
                     .email(loginDto.getEmail())

--- a/src/main/java/Spring/MindStone/service/tokenBlacklistService/TokenBlacklistService.java
+++ b/src/main/java/Spring/MindStone/service/tokenBlacklistService/TokenBlacklistService.java
@@ -1,0 +1,39 @@
+package Spring.MindStone.service.tokenBlacklistService;
+
+import Spring.MindStone.config.jwt.JwtTokenUtil;
+import Spring.MindStone.domain.tokenBlacklist.TokenBlackList;
+import Spring.MindStone.repository.tokenBlacklistRepository.TokenBlacklistRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+
+    private final TokenBlacklistRepository tokenBlacklistRepository;
+
+    public void addToBlackList(String refreshToken) {
+        LocalDateTime expiredAt = JwtTokenUtil.getExpirationDate(refreshToken);
+        TokenBlackList tokenBlackList = TokenBlackList.builder()
+                        .token(refreshToken)
+                        .expiredAt(expiredAt)
+                        .build();
+        tokenBlacklistRepository.save(tokenBlackList);
+    }
+
+    public boolean isTokenBlacklisted(String token) {
+        return tokenBlacklistRepository.existsByToken(token);
+    }
+
+    @Transactional
+    @Scheduled(cron = "0 0 3 * * ?")
+    public void deleteExpiredTokens() {
+        tokenBlacklistRepository.deleteAllByExpiredAtBefore(LocalDateTime.now());
+    }
+
+}

--- a/src/main/java/Spring/MindStone/web/controller/EmotionNoteController.java
+++ b/src/main/java/Spring/MindStone/web/controller/EmotionNoteController.java
@@ -1,4 +1,3 @@
-/*
 package Spring.MindStone.web.controller;
 
 import Spring.MindStone.apiPayload.ApiResponse;
@@ -45,5 +44,3 @@ public class EmotionNoteController {
 
 
 }
-
- */

--- a/src/main/java/Spring/MindStone/web/controller/EmotionWayController.java
+++ b/src/main/java/Spring/MindStone/web/controller/EmotionWayController.java
@@ -22,7 +22,7 @@ public class EmotionWayController {
     /**
      * 감정 관리 방법 조회
      */
-    /*
+
     @GetMapping
     @Operation(summary = "감정 관리 방법 조회 API", description = "회원 ID를 이용해 감정 관리 방법을 조회합니다.")
     public ApiResponse<EmotionWayResponseDto> getEmotionWay(
@@ -31,12 +31,10 @@ public class EmotionWayController {
         return ApiResponse.onSuccess(emotionWayService.getEmotionWay(memberId));
     }
 
-     */
-
     /**
      * 감정 관리 방법 수정
      */
-    /*
+
     @PutMapping
     @Operation(summary = "감정 관리 방법 수정 API", description = "회원 ID를 이용해 감정 관리 방법을 수정합니다.")
     public ApiResponse<String> updateEmotionWay(
@@ -48,5 +46,5 @@ public class EmotionWayController {
         return ApiResponse.onSuccess("감정 관리 방법이 성공적으로 수정되었습니다.");
     }
     
-     */
+
 }

--- a/src/main/java/Spring/MindStone/web/controller/MemberInfoController.java
+++ b/src/main/java/Spring/MindStone/web/controller/MemberInfoController.java
@@ -53,4 +53,13 @@ public class MemberInfoController {
         return ApiResponse.onSuccess(Map.of(memberInfoService.updatePassword(request, memberId), LocalDateTime.now()));
     }
 
+    @PostMapping("/deactivate")
+    @Operation(summary = "회원탈퇴 API", description = "회원탈퇴를 처리하는 API 입니다.")
+    public ApiResponse<String> memberDeactivate(@Valid @RequestBody MemberInfoRequestDTO.LogoutDto request,
+                                                @RequestHeader("Authorization") String authorization) {
+        Long memberId = JwtTokenUtil.extractMemberId(authorization);
+        memberInfoService.deactivateMember(memberId, request.getRefreshToken());
+        return ApiResponse.onSuccess("회원탈퇴가 완료되었습니다.");
+    }
+
 }

--- a/src/main/java/Spring/MindStone/web/dto/memberDto/MemberInfoRequestDTO.java
+++ b/src/main/java/Spring/MindStone/web/dto/memberDto/MemberInfoRequestDTO.java
@@ -52,7 +52,7 @@ public class MemberInfoRequestDTO {
     public static class RefreshTokenDTO {
 
         @NotNull
-        private String refreshToken;
+        String refreshToken;
         @NotBlank
         @Email
         String email;
@@ -90,6 +90,13 @@ public class MemberInfoRequestDTO {
         String oldPassword;
         @NotBlank
         String newPassword;
+    }
+
+    @Getter
+    @Setter
+    public static class LogoutDto {
+        @NotNull
+        String refreshToken;
     }
 
 }


### PR DESCRIPTION
1. 로그아웃
- TokenBlacklist 엔티티 생성 -> 로그아웃 시 refreshToken 저장
- accessToken 만료 후 탈취한 refreshToken으로 토큰 재발급 시도 -> 블랙리스트에 저장되어 재발급 불가
- 매일 새벽 3시에 TokenBlacklist 엔티티를 검사해 만료된 refreshToken 삭제

2. 회원탈퇴
- memberInfo의 status를 inactive로 변경
- inactive_date에 현재 날짜 삽입
- 블랙리스트에 refreshToken 저장
- MemberEntityListener : 리포지토리에서 MemberInfo 인스턴스를 가져올 때 이미 탈퇴 혹은 비활성화 된 회원일 때 에러 반환
- 매일 자정에 inactive로 전환된 지 30일이 지난 memberInfo 인스턴스 삭제