### PR TITLE
[Feat] 감정 추천, 홈화면 감정 기능 추가, 도커 추가

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,94 @@
+# github repository actions 페이지에 나타날 이름
+name: Mindstone CI/CD (using github actions & docker)
+
+# event trigger
+# main이나 develop 브랜치에 push, pull request가 되었을 때 실행
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main", "develop" ]
+
+# 코드의 내용을 이 파일을 실행하여 action을 수행하는 주체(Github Actions에서 사용하는 VM)가 읽을 수 있도록 허용합니다.
+permissions:
+  contents: read
+
+# 실제 실행될 내용들을 정의합니다.
+jobs:
+  build:
+    runs-on: ubuntu-latest  # ubuntu 최신 버전에서 script를 실행
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop' || github.event_name == 'push' && github.ref == 'refs/heads/develop' && github.event.head_commit.message != 'Merge pull request'
+    # develop 브랜치로의 pull request가 merge 되었을 때 github actions 작동
+    # 또는 develop 브랜치에 push가 발생하면 github actions 작동 (pr merge시 actions가 2번 발생하는 문제를 해결하기 위해 merge가 아닌 push때만 실행되도록 함)
+
+    # 지정한 저장소(현재 REPO)에서 코드를 워크플로우 환경으로 가져오도록 하는 github action
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: "temurin"
+
+        # gradle caching - 빌드 시간 향상
+      - name: Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # Github secrets로부터 데이터를 받아서, 워크 플로우에 파일을 생성
+      - name: make application.yml
+        run: |
+          mkdir -p ./src/main/resources  # 디렉토리가 없으면 생성
+          touch ./src/main/resources/application.yml  # application.yml 파일 생성
+          echo "${{ secrets.YML }}" > ./src/main/resources/application.yml     # github actions에서 설정한 값을 application.yml 파일에 쓰기
+        shell: bash
+
+      # gradle을 통해 소스를 빌드.
+      - name: Build with Gradle
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build -x test
+
+      # dockerfile을 통해 이미지를 빌드하고, 이를 docker hub로 push 합니다.
+      - name: Docker build and push Docker image
+        run: |
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_TOKEN }}
+          docker build -f Dockerfile -t ${{ secrets.DOCKER_USERNAME }}/mindstone .
+          docker push ${{ secrets.DOCKER_USERNAME }}/mindstone
+
+      # appleboy/ssh-action@master 액션을 사용하여 지정한 서버에 ssh로 접속하고, script를 실행합니다.
+      # script의 내용은 도커의 기존 프로세스들을 제거하고, docker hub로부터 방금 위에서 push한 내용을 pull 받아 실행하는 것입니다.
+      - name: Deploy to server
+        uses: appleboy/ssh-action@master
+        id: deploy
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          envs: GITHUB_SHA
+          script: |
+            # 실행 중인 컨테이너 정리
+            RUNNING_CONTAINER=$(docker ps -q --filter "ancestor=${{ secrets.DOCKER_USERNAME }}/mindstone")
+            if [ ! -z "$RUNNING_CONTAINER" ]; then
+              echo "Stopping running container..."
+              docker stop $RUNNING_CONTAINER
+              docker rm $RUNNING_CONTAINER
+            fi
+            
+            # 8080 포트를 점유 중인 프로세스 강제 종료
+            PID=$(sudo lsof -t -i:8080)
+            if [ ! -z "$PID" ]; then
+              echo "Killing process on port 8080..."
+              sudo kill -9 $PID
+            fi
+            
+            # 최신 이미지 pull 후 실행
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/mindstone
+            sudo docker run -d -p 8080:8080 ${{ secrets.DOCKER_USERNAME }}/mindstone
+            docker image prune -f

--- a/DockerFile
+++ b/DockerFile
@@ -1,0 +1,4 @@
+FROM openjdk:17-jdk-slim
+ARG JAR_FILE=/build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/src/main/java/Spring/MindStone/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/Spring/MindStone/apiPayload/code/status/ErrorStatus.java
@@ -43,8 +43,11 @@ public enum ErrorStatus implements BaseErrorCode {
 
     DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST,"DIARY4001","해당 날짜에 기록한 일기가 존재하지 않습니다."),
     DIARY_ISNT_MINE(HttpStatus.BAD_REQUEST,"DIARY4002","일기의 id와 자신의 id가 일치하지 않습니다."),
+
+    NO_MORE_AI_COUNT(HttpStatus.BAD_REQUEST,"GPTCREATE4001","더이상 ai 자동 생성을 할 수 없습니다."),
     //emotionNote(하루 일들) 관련 에러
     NOTE_NOT_FOUND(HttpStatus.BAD_REQUEST,"NOTE4001","해당 날짜에 기록한 일이 존재하지 않습니다.");
+
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/Spring/MindStone/domain/diary/DailyEmotionStatistic.java
+++ b/src/main/java/Spring/MindStone/domain/diary/DailyEmotionStatistic.java
@@ -32,25 +32,31 @@ public class DailyEmotionStatistic extends BaseEntity {
     private LocalDate date; // 생성 날짜
 
     @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 0")
-    private Integer angerFigure; // 분노 수치
+    private Integer angerFigure = 0; // 분노 수치
 
     @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 0")
-    private Integer depressionFigure; // 우울 수치
+    private Integer depressionFigure = 0; // 우울 수치
 
     @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 0")
-    private Integer sadFigure; // 슬픔 수치
+    private Integer sadFigure = 0; // 슬픔 수치
 
     @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 0")
-    private Integer calmFigure; // 슬픔 수치
+    private Integer calmFigure = 0; // 슬픔 수치
 
     @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 0")
-    private Integer joyFigure; // 기쁨 수치
+    private Integer joyFigure = 0; // 기쁨 수치
 
     @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 0")
-    private Integer thrillFigure; // 전율 수치
+    private Integer thrillFigure = 0; // 전율 수치
 
     @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 0")
-    private Integer happinessFigure; // 행복 수치
+    private Integer happinessFigure = 0; // 행복 수치
+
+    @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 3")
+    private Integer diaryAutoCreationCount = 3; // 일기자동생성횟수
+
+    @Column(nullable = false, columnDefinition = "INTEGER DEFAULT 10")
+    private Integer actionRecommandCount =10; // 행동추천횟수
 
     public void updateEmotion(EmotionList emotion, int value) {
         switch (emotion) {

--- a/src/main/java/Spring/MindStone/service/GptService.java
+++ b/src/main/java/Spring/MindStone/service/GptService.java
@@ -1,0 +1,90 @@
+package Spring.MindStone.service;
+
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatCompletionResult;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import com.theokanning.openai.completion.chat.ChatMessageRole;
+import com.theokanning.openai.service.OpenAiService;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GptService {
+    @Value("${openai.secret-key}")
+    private String SECRET_KEY;
+    private OpenAiService openAiService;
+
+
+    @PostConstruct
+    public void init() {
+        openAiService = new OpenAiService(SECRET_KEY, Duration.ofSeconds(45)); // 45초 내에 응답 안올 시 예외 던짐
+        // TODO openAiService 싱글톤으로 (OpenAiServiceWrapper 빈으로 감싸서 클래스 이곳 저곳에 제공?)
+    }
+
+    private final String USER = ChatMessageRole.USER.value();
+    private final String ASSISTANT = ChatMessageRole.ASSISTANT.value();
+    private final String SYSTEM = ChatMessageRole.SYSTEM.value();
+
+    private final List<ChatMessage> diaryPrompt = List.of(
+            new ChatMessage(SYSTEM, "You are an emotional diary generator that writes daily reflections in Korean."),
+            new ChatMessage(SYSTEM, "1. The input consists of daily activities described with action, emotion, and emotionScore (without time)."),
+            new ChatMessage(SYSTEM, "2. Arrange the activities in a natural order to ensure the diary feels coherent and follows a logical flow of events."),
+            new ChatMessage(SYSTEM, "3. Use casual and relatable language, avoiding formal speech. Write as if the user is talking to themselves"),
+            new ChatMessage(SYSTEM, "4. Highlight the user's emotional transitions throughout the day and summarize the overall sentiment at the end."),
+            new ChatMessage(SYSTEM, "5. Keep the diary concise, engaging, and authentic to the user's experiences."),
+            new ChatMessage(SYSTEM, "6. If no input is provided or the input is not understandable, write a reflection with the phrase like '이유 없이' to describe the emotion."),
+            new ChatMessage(SYSTEM, "7. If asked to regenerate, rewrite the diary with a different perspective or style while maintaining coherence and emotional flow."),
+            new ChatMessage(SYSTEM, "The diary must be written in Korean.")
+    );
+
+    public ChatCompletionRequest generateDiaryPrompt(List<ChatMessage> chatPrompt){
+        List<ChatMessage> promptMessage = new ArrayList<>();
+        promptMessage.addAll(diaryPrompt);
+        promptMessage.addAll(chatPrompt);
+
+        return ChatCompletionRequest.builder()
+                .model("gpt-3.5-turbo")
+                .messages(promptMessage)
+                .temperature(0.2)
+                .build();
+    }
+
+    private final List<ChatMessage> recommandPrompt = List.of(
+            new ChatMessage(SYSTEM, "You are an emotional diary generator that writes daily reflections in Korean."),
+            new ChatMessage(SYSTEM, "1. The input consists of daily activities described with action, emotion, and emotionScore (without time)."),
+            new ChatMessage(SYSTEM, "2. Arrange the activities in a natural order to ensure the diary feels coherent and follows a logical flow of events."),
+            new ChatMessage(SYSTEM, "3. Use casual and relatable language, avoiding formal speech. Write as if the user is talking to themselves"),
+            new ChatMessage(SYSTEM, "4. Highlight the user's emotional transitions throughout the day and summarize the overall sentiment at the end."),
+            new ChatMessage(SYSTEM, "5. Keep the diary concise, engaging, and authentic to the user's experiences."),
+            new ChatMessage(SYSTEM, "6. If no input is provided or the input is not understandable, write a reflection with the phrase like '이유 없이' to describe the emotion."),
+            new ChatMessage(SYSTEM, "7. If asked to regenerate, rewrite the diary with a different perspective or style while maintaining coherence and emotional flow."),
+            new ChatMessage(SYSTEM, "The diary must be written in Korean.")
+    );
+
+    public ChatCompletionRequest generateRecommandPrompt(List<ChatMessage> chatPrompt){
+        List<ChatMessage> promptMessage = new ArrayList<>();
+        promptMessage.addAll(recommandPrompt);
+        promptMessage.addAll(chatPrompt);
+
+        return ChatCompletionRequest.builder()
+                .model("gpt-3.5-turbo")
+                .messages(promptMessage)
+                .temperature(0.2)
+                .build();
+    }
+
+    public String getOpenAiResult(ChatCompletionRequest request){
+        Long startTime = System.currentTimeMillis();
+        ChatCompletionResult result = openAiService.createChatCompletion(request);
+        Long endTime = System.currentTimeMillis();
+        System.out.printf("GPTTranslationService: translation took %d seconds, consumed %d tokens total (prompt %d, completion %d)%n", (endTime-startTime)/1000, result.getUsage().getTotalTokens(), result.getUsage().getPromptTokens(), result.getUsage().getCompletionTokens());
+        return result.getChoices().get(0).getMessage().getContent();
+    }
+}

--- a/src/main/java/Spring/MindStone/service/GptService.java
+++ b/src/main/java/Spring/MindStone/service/GptService.java
@@ -57,15 +57,32 @@ public class GptService {
     }
 
     private final List<ChatMessage> recommandPrompt = List.of(
-            new ChatMessage(SYSTEM, "You are an emotional diary generator that writes daily reflections in Korean."),
-            new ChatMessage(SYSTEM, "1. The input consists of daily activities described with action, emotion, and emotionScore (without time)."),
-            new ChatMessage(SYSTEM, "2. Arrange the activities in a natural order to ensure the diary feels coherent and follows a logical flow of events."),
-            new ChatMessage(SYSTEM, "3. Use casual and relatable language, avoiding formal speech. Write as if the user is talking to themselves"),
-            new ChatMessage(SYSTEM, "4. Highlight the user's emotional transitions throughout the day and summarize the overall sentiment at the end."),
-            new ChatMessage(SYSTEM, "5. Keep the diary concise, engaging, and authentic to the user's experiences."),
-            new ChatMessage(SYSTEM, "6. If no input is provided or the input is not understandable, write a reflection with the phrase like '이유 없이' to describe the emotion."),
-            new ChatMessage(SYSTEM, "7. If asked to regenerate, rewrite the diary with a different perspective or style while maintaining coherence and emotional flow."),
-            new ChatMessage(SYSTEM, "The diary must be written in Korean.")
+            // 사용자는 직업과 MBTI를 입력하면 스트레스 해소를 위한 3가지 행동을 추천받음
+            new ChatMessage(SYSTEM, "You are an assistant that suggests 3 actions"),
+            new ChatMessage(SYSTEM, "for relieving stress or feeling down,"),
+            new ChatMessage(SYSTEM, "considering the user's job and MBTI type."),
+
+            // 추천된 행동은 트렌디하고, 친구·동료·선후배 관계에서 활용할 수 있는 방식이어야 함
+            new ChatMessage(SYSTEM, "The recommendations should be trendy and socially relatable,"),
+            new ChatMessage(SYSTEM, "fitting into relationships such as friends, colleagues, or mentors."),
+
+            // 현재 유행하는 취미, 엔터테인먼트, 사회적 활동을 반영해야 함
+            new ChatMessage(SYSTEM, "Ensure that the recommendations align with"),
+            new ChatMessage(SYSTEM, "current trends in entertainment, hobbies, and social activities."),
+
+            // 출력값은 행동 3개만, 쉼표(,)로 구분하여 제공 (추가 설명 없이)
+            new ChatMessage(SYSTEM, "The output must be only the three actions,"),
+            new ChatMessage(SYSTEM, "separated by commas, with no additional explanation."),
+
+            // 사용자가 이전에 추천받은 행동을 제공할 수도 있으며, 중복되지 않도록 새롭게 추천해야 함
+            new ChatMessage(SYSTEM, "The user may provide previously recommended actions,"),
+            new ChatMessage(SYSTEM, "and you must ensure that the new suggestions do not include them."),
+
+            // 반드시 한국어로 출력되도록 설정 (입력 언어와 상관없이)
+            new ChatMessage(SYSTEM, "The output must be in Korean, regardless of the input language."),
+
+            // 추천하는 행동은 10단어 이하로 제한
+            new ChatMessage(SYSTEM, "Each recommended action must be within 10 words.")
     );
 
     public ChatCompletionRequest generateRecommandPrompt(List<ChatMessage> chatPrompt){

--- a/src/main/java/Spring/MindStone/service/diaryService/DailyEmotionStatisticService.java
+++ b/src/main/java/Spring/MindStone/service/diaryService/DailyEmotionStatisticService.java
@@ -32,8 +32,19 @@ public class DailyEmotionStatisticService {
     public SimpleEmotionStatisticDto getStatistic(Long memberId) {
         MemberInfo memberInfo = memberInfoService.findMemberById(memberId);
         DailyEmotionStatistic statistics = (DailyEmotionStatistic) dailyEmotionStatisticRepository.findByDateAndMemberInfo(LocalDate.now(),memberInfo)
-                .orElseGet(() -> new DailyEmotionStatistic(memberInfo, LocalDate.now()));
+                .orElseGet(() ->dailyEmotionStatisticRepository.save(new DailyEmotionStatistic(memberInfo, LocalDate.now())) );
 
         return new SimpleEmotionStatisticDto(statistics);
+    }
+
+    public DailyEmotionStatistic getStatisticEntity(Long memberId) {
+        MemberInfo memberInfo = memberInfoService.findMemberById(memberId);
+        DailyEmotionStatistic statistics = (DailyEmotionStatistic) dailyEmotionStatisticRepository.findByDateAndMemberInfo(LocalDate.now(),memberInfo)
+                .orElseGet(() ->dailyEmotionStatisticRepository.save(new DailyEmotionStatistic(memberInfo, LocalDate.now())) );
+        return statistics;
+    }
+
+    public void updateStatistic(DailyEmotionStatistic statistics) {
+        dailyEmotionStatisticRepository.save(statistics);
     }
 }

--- a/src/main/java/Spring/MindStone/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/Spring/MindStone/service/diaryService/DiaryCommandServiceImpl.java
@@ -55,7 +55,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService {
     private final String SYSTEM = ChatMessageRole.SYSTEM.value();
     private final DailyEmotionStatisticService dailyEmotionStatisticService;
 
-    public void checkGPTCount(Long memberId){
+    private void checkGPTCount(Long memberId){
         DailyEmotionStatistic statisticEntity = dailyEmotionStatisticService.getStatisticEntity(memberId);
         if(statisticEntity.getDiaryAutoCreationCount() > 0){
             statisticEntity.setDiaryAutoCreationCount(statisticEntity.getDiaryAutoCreationCount() - 1);

--- a/src/main/java/Spring/MindStone/service/emotionNoteService/EmotionNoteService.java
+++ b/src/main/java/Spring/MindStone/service/emotionNoteService/EmotionNoteService.java
@@ -10,6 +10,7 @@ import Spring.MindStone.repository.emotionNoteRepository.EmotionNoteRepository;
 import Spring.MindStone.service.diaryService.DailyEmotionStatisticService;
 import Spring.MindStone.service.memberInfoService.MemberInfoService;
 import Spring.MindStone.web.dto.emotionNoteDto.EmotionNoteSaveDTO;
+import Spring.MindStone.web.dto.emotionNoteDto.EmotionNoteStressSaveDTO;
 import Spring.MindStone.web.dto.emotionNoteDto.SimpleEmotionNoteDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,10 +33,25 @@ public class EmotionNoteService {
                 .emotion(EmotionList.fromString(note.getEmotion()))
                 .content(note.getContent()).build();
 
+        //호출해서 감정이 저장될때마다 감정통계 엔티티를 추가로 업데이트 시킴.
         dailyEmotionStatisticService.saveStatistics(memberInfo, LocalDate.now()
                 ,EmotionList.fromString(note.getEmotion()),note.getEmotionFigure());
 
         emotionNoteRepository.save(emotionNote);
         return new SimpleEmotionNoteDTO(emotionNote);
+    }
+
+    public SimpleEmotionNoteDTO saveStressEmotionNote(EmotionNoteStressSaveDTO request, Long memberId){
+        EmotionNoteSaveDTO emotionNoteDTO;
+        if(request.getTime().equals("0시간 0분")||request.getTime().isBlank()){
+            emotionNoteDTO = EmotionNoteSaveDTO.builder().emotionFigure(request.getEmotionFigure())
+                    .emotion(request.getEmotion()).content("스트레스를 받아서 : "+request.getContent() + "을 했다.").build();
+        }else{
+            emotionNoteDTO = EmotionNoteSaveDTO.builder().emotionFigure(request.getEmotionFigure())
+                    .emotion(request.getEmotion()).content("스트레스를 받아서 : "+request.getContent() + "을 했고, 얼마나 했는지: " + request.getTime()).build();
+        }
+
+        return saveEmotionNote(emotionNoteDTO, memberId);
+
     }
 }

--- a/src/main/java/Spring/MindStone/service/emotionWayService/EmotionWayService.java
+++ b/src/main/java/Spring/MindStone/service/emotionWayService/EmotionWayService.java
@@ -6,14 +6,33 @@ import Spring.MindStone.repository.memberRepository.MemberInfoRepository;
 import Spring.MindStone.repository.memberRepository.MemberInterestRepository;
 import Spring.MindStone.web.dto.emotionWayDto.EmotionWayRequestDto;
 import Spring.MindStone.web.dto.emotionWayDto.EmotionWayResponseDto;
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatCompletionResult;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import com.theokanning.openai.completion.chat.ChatMessageRole;
+import com.theokanning.openai.service.OpenAiService;
+import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class EmotionWayService {
+
+    @Value("${openai.secret-key}")
+    private String SECRET_KEY;
+    private OpenAiService openAiService;
+
+    private final String USER = ChatMessageRole.USER.value();
+    private final String ASSISTANT = ChatMessageRole.ASSISTANT.value();
+    private final String SYSTEM = ChatMessageRole.SYSTEM.value();
 
     private final MemberInfoRepository memberInfoRepository;
     private final MemberInterestRepository memberInterestRepository;
@@ -58,4 +77,36 @@ public class EmotionWayService {
         memberInfoRepository.save(member);
         memberInterestRepository.save(memberInterest);
     }
+
+    private final List<ChatMessage> systemPrompt = List.of(
+
+    );
+
+    @PostConstruct
+    public void init() {
+        openAiService = new OpenAiService(SECRET_KEY, Duration.ofSeconds(45)); // 45초 내에 응답 안올 시 예외 던짐
+        // TODO openAiService 싱글톤으로 (OpenAiServiceWrapper 빈으로 감싸서 클래스 이곳 저곳에 제공?)
+    }
+
+
+    private ChatCompletionRequest generatePrompt(List<ChatMessage> systemPrompt, List<ChatMessage> chatPrompt){
+        List<ChatMessage> promptMessage = new ArrayList<>();
+        promptMessage.addAll(systemPrompt);
+        promptMessage.addAll(chatPrompt);
+
+        return ChatCompletionRequest.builder()
+                .model("gpt-3.5-turbo")
+                .messages(promptMessage)
+                .temperature(0.2)
+                .build();
+    }
+
+    private String getOpenAiResult(ChatCompletionRequest request){
+        Long startTime = System.currentTimeMillis();
+        ChatCompletionResult result = openAiService.createChatCompletion(request);
+        Long endTime = System.currentTimeMillis();
+        System.out.printf("GPTTranslationService: translation took %d seconds, consumed %d tokens total (prompt %d, completion %d)%n", (endTime-startTime)/1000, result.getUsage().getTotalTokens(), result.getUsage().getPromptTokens(), result.getUsage().getCompletionTokens());
+        return result.getChoices().get(0).getMessage().getContent();
+    }
+
 }

--- a/src/main/java/Spring/MindStone/web/controller/DiaryRestController.java
+++ b/src/main/java/Spring/MindStone/web/controller/DiaryRestController.java
@@ -105,7 +105,7 @@ public class DiaryRestController {
     }
 
     @GetMapping("/calendar")
-    @Operation(summary = "특정 년월 달력 요청")
+    @Operation(summary = "특정 년월 달력 요청", description = "이거 list로 보내주는거에요")
     @Parameters({
             @Parameter(name = "year", description = "년도"),
             @Parameter(name = "month", description = "월")
@@ -119,5 +119,21 @@ public class DiaryRestController {
         Long memberId = JwtTokenUtil.extractMemberId(authorization);
         return ApiResponse.onSuccess(diaryQueryService.getDiaryCalendar(year,month,memberId));
     }
+
+    /*@GetMapping("/calendar/repot")
+    @Operation(summary = "특정 년월 달력 요청")
+    @Parameters({
+            @Parameter(name = "year", description = "년도"),
+            @Parameter(name = "month", description = "월")
+    })
+    public ApiResponse<List<DiaryCallendarDTO>> getCalendarReport(
+            @RequestParam("year") @NotNull int year,
+            @RequestParam("month") int month,
+            @RequestHeader("Authorization") String authorization
+    ){
+        System.out.println("GET api/diary/calendar/report");
+        Long memberId = JwtTokenUtil.extractMemberId(authorization);
+        return ApiResponse.onSuccess(diaryQueryService.getDiaryCalendar(year,month,memberId));
+    }*/
 
 }

--- a/src/main/java/Spring/MindStone/web/controller/EmotionNoteController.java
+++ b/src/main/java/Spring/MindStone/web/controller/EmotionNoteController.java
@@ -2,12 +2,14 @@ package Spring.MindStone.web.controller;
 
 import Spring.MindStone.apiPayload.ApiResponse;
 import Spring.MindStone.config.jwt.JwtTokenUtil;
+import Spring.MindStone.domain.emotion.EmotionNote;
 import Spring.MindStone.repository.emotionNoteRepository.EmotionNoteRepository;
 import Spring.MindStone.service.diaryService.DailyEmotionStatisticService;
 import Spring.MindStone.service.emotionNoteService.EmotionNoteQueryService;
 import Spring.MindStone.service.emotionNoteService.EmotionNoteService;
 import Spring.MindStone.web.dto.emotionDto.SimpleEmotionStatisticDto;
 import Spring.MindStone.web.dto.emotionNoteDto.EmotionNoteSaveDTO;
+import Spring.MindStone.web.dto.emotionNoteDto.EmotionNoteStressSaveDTO;
 import Spring.MindStone.web.dto.emotionNoteDto.SimpleEmotionNoteDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,6 +35,16 @@ public class EmotionNoteController {
         Long memberId = JwtTokenUtil.extractMemberId(authorization);
 
         return ApiResponse.onSuccess(emotionNoteService.saveEmotionNote(emotionNoteDTO,memberId));
+    }
+
+    @PostMapping("/stress")
+    @Operation(summary = "슬픈 감정을 골랐을때, 스트레스를 푸는 행동을 한 후 기록 저장", description = "감정에 대한 일과 저장")
+    ApiResponse<SimpleEmotionNoteDTO> saveStressEmotionNote(
+            @Valid @RequestBody EmotionNoteStressSaveDTO request,
+            @RequestHeader("Authorization") String authorization) {
+        Long memberId = JwtTokenUtil.extractMemberId(authorization);
+
+        return ApiResponse.onSuccess(emotionNoteService.saveStressEmotionNote(request ,memberId));
     }
 
     @GetMapping("/statistic")

--- a/src/main/java/Spring/MindStone/web/controller/EmotionWayController.java
+++ b/src/main/java/Spring/MindStone/web/controller/EmotionWayController.java
@@ -4,9 +4,12 @@ package Spring.MindStone.web.controller;
 import Spring.MindStone.apiPayload.ApiResponse;
 import Spring.MindStone.config.jwt.JwtTokenUtil;
 import Spring.MindStone.service.emotionWayService.EmotionWayService;
+import Spring.MindStone.web.dto.emotionWayDto.AiRecommandResponseDto;
 import Spring.MindStone.web.dto.emotionWayDto.EmotionWayRequestDto;
 import Spring.MindStone.web.dto.emotionWayDto.EmotionWayResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -44,6 +47,29 @@ public class EmotionWayController {
         Long memberId = JwtTokenUtil.extractMemberId(authorization);
         emotionWayService.updateEmotionWay(memberId, request);
         return ApiResponse.onSuccess("감정 관리 방법이 성공적으로 수정되었습니다.");
+    }
+
+    @GetMapping("/stress/gpt")
+    @Operation(summary = "GPT에게 행동 추천받기", description = "슬픈감정일때 행동추천을 받는걸 gpt로 받습니다.")
+    @Parameters({
+            @Parameter(name = "previousRecommand", description = "이미 받았던 추천 없으면 공백으로")
+    })
+    public ApiResponse<AiRecommandResponseDto> getAIRecommand(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam("previousRecommand") String previousRecommand
+    ){
+        Long memberId = JwtTokenUtil.extractMemberId(authorization);
+        return ApiResponse.onSuccess(emotionWayService.getAiRecommand(memberId, previousRecommand));
+    }
+
+    @GetMapping("/stress")
+    @Operation(summary = "자신이 적은 행동 랜덤으로 3개 추천받기",
+            description = "슬픈감정일때 행동추천을 받는걸 자신의 껄로 3개 받습니다.")
+    public ApiResponse<String> getRecommand(
+            @RequestHeader("Authorization") String authorization
+    ){
+        Long memberId = JwtTokenUtil.extractMemberId(authorization);
+        return ApiResponse.onSuccess(emotionWayService.getRecommand(memberId));
     }
     
 

--- a/src/main/java/Spring/MindStone/web/dto/emotionNoteDto/EmotionNoteStressSaveDTO.java
+++ b/src/main/java/Spring/MindStone/web/dto/emotionNoteDto/EmotionNoteStressSaveDTO.java
@@ -1,0 +1,23 @@
+package Spring.MindStone.web.dto.emotionNoteDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class EmotionNoteStressSaveDTO {
+    @NotNull(message = "무슨 감정을 느꼈는지 적어야합니다.")
+    @Schema(description = "감정", example = "ANGER, DEPRESSION, SAD, CALM, JOY, THRILL, HAPPINESS")
+    private String emotion;
+
+    @NotNull(message = "감정을 얼마나 느꼈는지 적어야합니다.")
+    @Schema(description = "감정수치", example = "10~100")
+    private Integer emotionFigure;
+
+    @NotNull(message = "어떤 스트레스 푸는 행동을 했는지 적어야합니다.")
+    @Schema(description = "스트레스 푼 행동", example = "게임하기")
+    private String content;
+
+    @Schema(description = "얼마나 했는지 시간 작성", example = "1시간 30분")
+    private String time;
+}

--- a/src/main/java/Spring/MindStone/web/dto/emotionWayDto/AiRecommandResponseDto.java
+++ b/src/main/java/Spring/MindStone/web/dto/emotionWayDto/AiRecommandResponseDto.java
@@ -1,0 +1,9 @@
+package Spring.MindStone.web.dto.emotionWayDto;
+
+import lombok.Builder;
+
+@Builder
+public class AiRecommandResponseDto {
+    String recommand;
+    String previousRecommand;
+}

--- a/src/main/java/Spring/MindStone/web/dto/emotionWayDto/AiRecommandResponseDto.java
+++ b/src/main/java/Spring/MindStone/web/dto/emotionWayDto/AiRecommandResponseDto.java
@@ -1,8 +1,15 @@
 package Spring.MindStone.web.dto.emotionWayDto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+
+@Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class AiRecommandResponseDto {
     String recommand;
     String previousRecommand;


### PR DESCRIPTION
## 📍 작업 내용
홈화면에서의 슬픈 감정일때의 행동 추천 기능과, 그외에 기록하는 것을 만들었음.
블로그 읽으면서 도커파일과 깃허브 액션을 추가했음. develop, main이 머지 됐을때 서버가 업데이트 되는 기능.



## 추가 구현해야할 것

감정 달력 리스트와 리포트 구현하고 마무리

