### PR TITLE
fix : 멤버 인터레스트 여러개 생성되는 오류 수정

### DIFF
--- a/src/main/java/Spring/MindStone/domain/member/MemberInfo.java
+++ b/src/main/java/Spring/MindStone/domain/member/MemberInfo.java
@@ -71,8 +71,8 @@ public class MemberInfo extends BaseEntity {
     @Column(nullable = false, length = 15, columnDefinition = "VARCHAR(15) DEFAULT 'USER'")
     private Role role;
 
-    @OneToMany(mappedBy = "memberInfo", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MemberInterest> memberInterestList = new ArrayList<>();        // 유저 관심사 리스트
+    @OneToOne(mappedBy = "memberInfo", cascade = CascadeType.ALL, orphanRemoval = true)
+    private MemberInterest memberInterestList;        // 유저 관심사 리스트
 
     @OneToMany(mappedBy = "memberInfo", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DailyDiary> dailyDiaryList = new ArrayList<>();

--- a/src/main/java/Spring/MindStone/domain/member/MemberInterest.java
+++ b/src/main/java/Spring/MindStone/domain/member/MemberInterest.java
@@ -20,7 +20,7 @@ public class MemberInterest extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // ID (PK)
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private MemberInfo memberInfo; // 회원 ID (FK, Member와 관계 설정)
 


### PR DESCRIPTION
기존 OnboardingService에서 기존에 엔티티가 있는지 확인하지 않고 무작정 새로 객체를 생성후 save하였기에 MemberInterest를 반환할때 여러개의 객체를 리턴하는 현상 발생

온보딩서비스에서 객체가 있는지 확인하구 있다면 수정, 없다면 생성하게 로직을 변경하였음.

그리고 멤버인터레스트와 멤버 인포의 관계가 1:1 관계로 변형되었기 떄문에 따라서 객체도 onetoone관계로 변형하였음.